### PR TITLE
[WIP] Feature stylus support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,4 @@ typings/
 dist/
 
 package-lock.json
+yarn.lock

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ clean    remove all files in dist <清理dist>
 compile  compile all source files to dist <编译所有源文件>
 js       compile ts/js files to `.js` <编译生成js>
 wxs      compile wxts/wxs files to `.wxs` <编译生成wxs>
-wxss     compile scss/sass/css/wxss to `.wxss` <编译生成wxss>
+wxss     compile scss/sass/css/wxss/stylus to `.wxss` <编译生成wxss>
 wxml     compile html/wxml files to `.wxml` <编译生成wxml>
 json     compile all json/jsonc files to `.json` <编译生成json>
 image    compresse all images in source to dist <压缩所有图片>
@@ -175,6 +175,7 @@ npx miniprogram-build init
 -   [x] 显示报错位置
 -   [x] break errors
 -   [ ] cache
+-   [ ] compile stylus
 
 ## test examples
 

--- a/bin/mp-build.js
+++ b/bin/mp-build.js
@@ -79,7 +79,7 @@ var argv = require("yargs")
     .command(cb("wxs"), cd(`compile wxs/wxts to \`wxs\` ${odc("<编译生成wxs>")}`))
     .command(cb("wxts"), cd(`compile WeiXinTypeScript to \`wxs\` ${odc("<编译wxts>")}`))
     .command(cb("wxjs"), cd(`compile wxs as JavaScript ${odc("<编译wxs>")}`))
-    .command(cb("wxss"), cd(`compile scss/sass/css/wxss to \`.wxss\` ${odc("<编译生成wxss>")}`))
+    .command(cb("wxss"), cd(`compile scss/sass/css/wxss/stylus to \`.wxss\` ${odc("<编译生成wxss>")}`))
     .command(cb("wxml"), cd(`compile html/wxml files to \`.wxml\` ${odc("<编译生成wxml>")}`))
     .command(cb("json"), cd(`compile all json/jsonc files to json ${odc("<编译生成json>")}`))
     .command(cb("image"), cd(`compresse all images in source to dist ${odc("<压缩所有图片>")}`))
@@ -91,7 +91,7 @@ var argv = require("yargs")
     .command(cw("wxs-watch"), cd(`watch changes of .wxs/.wxts ${odc("<监测.wxs/.wxts>")}`))
     .command("wxts-watch", false) //"watch changes of .wxts files ${odc("<监测wxts改动>"
     .command("wxjs-watch", false) //"watch changes of .wxs files ${odc("<监测wxs改动>"
-    .command(cw("wxss-watch"), cd(`watch changes of scss/sass/css/wxss ${odc("<实时生成wxss>")}`))
+    .command(cw("wxss-watch"), cd(`watch changes of scss/sass/css/wxss/stylus ${odc("<实时生成wxss>")}`))
     .command(cw("wxml-watch"), cd(`watch changes of html/wxml files ${odc("<实时生成wxml>")}`))
     .command(cw("json-watch"), cd(`watch changes of all json/jsonc files ${odc("<实时生成json>")}`))
     .command(cw("image-watch"), cd(`watch changes of all images in source ${odc("<实时压缩图片>")}`))
@@ -108,4 +108,3 @@ if (argv._.length === 1 && argv._[0] === "init") {
     const tasks = require("../src/task")
     tasks.$execute(argv._.length === 0 ? ["dev"] : argv._);
 }
-

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
         "gulp-better-rollup": "^4.0.1",
         "gulp-rename": "^1.4.0",
         "gulp-sourcemaps": "^2.6.5",
+        "gulp-stylus": "^2.7.0",
         "gulp-typescript": "^5.0.1",
         "imagemin": "^6.1.0",
         "json5": "^2.1.0",
@@ -64,6 +65,7 @@
         "rimraf": "^2.6.3",
         "rollup": "^1.13.1",
         "sass": "^1.20.3",
+        "stylus": "^0.54.5",
         "through2": "^3.0.1",
         "ts-transform-paths": "^2.0.0",
         "yargs": "^13.2.4"

--- a/src/compiler/compile-stylus.js
+++ b/src/compiler/compile-stylus.js
@@ -1,0 +1,123 @@
+///@ts-check
+"use strict";
+// var path = require("path");
+var gulp = require("gulp");
+// var sourcemaps = require("gulp-sourcemaps");
+// const rename = require("gulp-rename");
+
+const stylus = require("gulp-stylus");
+const cleanCSS = require("../lib/clean-css");
+var inline = require("../lib/inline");
+// var empty = require("../lib/empty");
+// var wxssImporter = require("../lib/wxss-importer");
+var replace = require("../lib/multi-replace");
+var error = require("../log/error");
+const debug = require("../log/compile");
+const size = require("../log/size");
+var TITLE = "wxss:";
+/**
+ * 编译 stylus
+ * @param {object} config
+ * @param {string|string[]} stylusFile  编译源
+ * @returns {NodeJS.ReadWriteStream}
+ */
+function compileStylus(config, stylusFile) {
+    // var postCssPlgins = [
+    //     // autoprefixer({
+    //     //     browsers: [
+    //     //         // ios
+    //     //         "iOS >= 8",
+    //     //         // android
+    //     //         "ChromeAndroid >= 53",
+    //     //     ],
+    //     // }),
+    // ];
+    // if (config.release) {
+    //     postCssPlgins.push(cssnano());
+    // }
+    return gulp
+        .src(stylusFile, { base: config.src })
+        // .pipe(config.release ? empty() : sourcemaps.init())
+        .pipe(
+            debug({
+                title: TITLE,
+                // dist: config.dist,
+                distExt: ".wxss",
+            }),
+        )
+        .pipe(stylus())
+        .on("error", error("wxss"))
+        // .pipe(
+        //     replace(/@import url\(["']?([\w\/\.\-\_]*)["']?\)/g, ($1, $2) => {
+        //         return '@import "' + $2 + '"';
+        //     }),
+        // )
+        .pipe(inline(config))
+        .pipe(
+            cleanCSS({
+                sourceMap: false,
+                inline: ['none'],
+                format: config.release ? "minify" : "beautify",
+                level: {
+                    1: {
+                        all: true,
+                        specialComments: config.release ? 0 : "all",
+                    },
+                    2: {
+                        restructureRules: true, // controls rule restructuring;
+                    },
+                },
+                compatibility: {
+                    colors: {
+                        opacity: true, // controls `rgba()` / `hsla()` color support
+                    },
+                    properties: {
+                        backgroundClipMerging: true, // controls background-clip merging into shorthand
+                        backgroundOriginMerging: true, // controls background-origin merging into shorthand
+                        backgroundSizeMerging: true, // controls background-size merging into shorthand
+                        colors: true, // controls color optimizations
+                        ieBangHack: false, // controls keeping IE bang hack
+                        ieFilters: false, // controls keeping IE `filter` / `-ms-filter`
+                        iePrefixHack: false, // controls keeping IE prefix hack
+                        ieSuffixHack: false, // controls keeping IE suffix hack
+                        merging: true, // controls property merging based on understandability
+                        shorterLengthUnits: false, // controls shortening pixel units into `pc`, `pt`, or `in` units
+                        spaceAfterClosingBrace: false, // controls keeping space after closing brace - `url() no-repeat` into `url()no-repeat`
+                        urlQuotes: true, // controls keeping quoting inside `url()`
+                        zeroUnits: true, // controls removal of units `0` value
+                    },
+                    selectors: {
+                        adjacentSpace: false, // controls extra space before `nav` element
+                        ie7Hack: false, // controls removal of IE7 selector hacks, e.g. `*+html...`
+                        // mergeablePseudoClasses: [":active"], // controls a whitelist of mergeable pseudo classes
+                        // mergeablePseudoElements: ["::after"], // controls a whitelist of mergeable pseudo elements
+                        mergeLimit: 8191, // controls maximum number of selectors in a single rule (since 4.1.0)
+                        multiplePseudoMerging: true, // controls merging of rules with multiple pseudo classes / elements (since 4.1.0)
+                    },
+                    units: {
+                        ch: false, // controls treating `ch` as a supported unit
+                        in: false, // controls treating `in` as a supported unit
+                        pc: false, // controls treating `pc` as a supported unit
+                        pt: false, // controls treating `pt` as a supported unit
+                        rem: true, // controls treating `rem` as a supported unit
+                        vh: true, // controls treating `vh` as a supported unit
+                        vm: true, // controls treating `vm` as a supported unit
+                        vmax: true, // controls treating `vmax` as a supported unit
+                        vmin: true, // controls treating `vmin` as a supported unit
+                        rpx: true, // controls treating `vmin` as a supported unit
+                    },
+                },
+            }),
+        )
+        .pipe(
+            replace(/@import url\(["']?([\w\/\.\-\_]*)["']?\)/g, ($1, $2) => {
+                return '@import "' + $2 + '"';
+            }),
+        )
+        // .pipe(config.release ? empty() : sourcemaps.write())
+        // .pipe(rename({ extname: ".wxss" }))
+        .pipe(gulp.dest(config.dist))
+        .pipe(size({ title: TITLE, showFiles: true }));
+}
+
+module.exports = compileStylus;

--- a/src/lib/wxss-importer.js
+++ b/src/lib/wxss-importer.js
@@ -94,7 +94,7 @@ module.exports = function importer(url, prev, done) {
         // 引用的 node_modules 再次引用其他文件
         const file = path.resolve(path.dirname(prev), url);
         return { file: syncFile(file) }
-    } else if (url.endsWith(".wxss") && !fs.existsSync(url + '.scss') && !fs.existsSync(url + '.css') && !fs.existsSync(url + '.sass')) {
+    } else if (url.endsWith(".wxss") && !fs.existsSync(url + '.scss') && !fs.existsSync(url + '.css') && !fs.existsSync(url + '.sass') && !fs.existsSync(url + '.styl') && !fs.existsSync(url + '.stylus')) {
         // 引用本地wxss 并保持不变
         // keep import 
         // console.log(url);

--- a/src/lib/wxss-importer.js
+++ b/src/lib/wxss-importer.js
@@ -94,7 +94,7 @@ module.exports = function importer(url, prev, done) {
         // 引用的 node_modules 再次引用其他文件
         const file = path.resolve(path.dirname(prev), url);
         return { file: syncFile(file) }
-    } else if (url.endsWith(".wxss") && !fs.existsSync(url + '.scss') && !fs.existsSync(url + '.css') && !fs.existsSync(url + '.sass') && !fs.existsSync(url + '.styl') && !fs.existsSync(url + '.stylus')) {
+    } else if (url.endsWith(".wxss") && !fs.existsSync(url + '.scss') && !fs.existsSync(url + '.css') && !fs.existsSync(url + '.sass')) {
         // 引用本地wxss 并保持不变
         // keep import 
         // console.log(url);

--- a/src/tasks/wxss.js
+++ b/src/tasks/wxss.js
@@ -6,6 +6,7 @@ var gulp = require('gulp');
 var extToSrc = require('../lib/ext-to-glob');
 var unlink = require('../lib/unlink');
 var compileWxss = require('../compiler/compile-wxss');
+var compileStylus = require('../compiler/compile-stylus');
 var watchLog = require('../log/watch');
 
 var WXSS_EXTS = ['scss', 'sass', 'css', 'wxss'];
@@ -14,6 +15,7 @@ var WXSS_EXTS = ['scss', 'sass', 'css', 'wxss'];
  * @param {object} config
  */
 function compile(config) {
+    compileStylus(config, extToSrc(config, ['stylus', 'styl']))
     return compileWxss(config, extToSrc(config, WXSS_EXTS));
 }
 
@@ -40,6 +42,7 @@ exports.watch = function (config) {
         if (isAsset(file, config)) {
             return compile(config);//依赖资源文件更改全部编译
         } else {
+            compileStylus(config, file)
             return compileWxss(config, file);
         }
     };

--- a/test/src/pages/stylus/index.html
+++ b/test/src/pages/stylus/index.html
@@ -1,0 +1,12 @@
+<view class="x y">
+    <text hidden="{{ true }}">hello</text>
+    <input type="text" value="{{ x }}" bind:type="type"/>
+</view>
+<view>
+    <button disabled="{{true}}"></button>
+</view>
+
+<button form-type="submit" class="wechat" open-type="share" data-share="group"> 
+    <view class="icon"/> 
+    <view class="text">微信群交换</view> 
+</button>

--- a/test/src/pages/stylus/index.stylus
+++ b/test/src/pages/stylus/index.stylus
@@ -1,0 +1,3 @@
+
+.x
+    background-color red

--- a/test/src/pages/stylus/index.ts
+++ b/test/src/pages/stylus/index.ts
@@ -1,0 +1,7 @@
+import { test } from "/lib/test";
+
+console.log(test);
+Page({
+
+    
+})


### PR DESCRIPTION
我尝试支持编译 stylus 文件, 但失败了.

### 复现步骤
1. 切换分支, 
2. 安装依赖, 
3. 运行 npm run test:full, 
4. 查看 test/dist/pages/stylus/index.wxss 其中并没有内容 (期望含有 `.b {background-color: red;}`)

### 修改过程
1. 添加依赖 `stylus` `gulp-stylus`
2. 复制 `src/compiler/compile-scss.js` to `src/compiler/compile-stylus.js`
3. 修改 `src/compiler/compile-stylus.js`以下内容
  ``` js
   .pipe(
      sass({
          ///@ts-ignore
          importer: wxssImporter,
          errLogToConsole: true,
          outputStyle: "expanded",
          includePaths: [path.join(config.src, config.assets || "./")],
      }),
   )
  /// 修改为 (暂时只简单编译stylus文件)
  const stylus = require('gulp-stylus')
  ...
  .pipe(stylus())
  ```
4.  修改其他文件 (参见diff)

不知道为什么编译出来的 wxss 是个空文件, 不知道哪里出了问题, 恳请指点 🙏

> refer #29 