### PR TITLE
feat: 允许在scss文件中注入env变量

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ npx miniprogram-build init
     -   [x] compile
         -   `scss`/`sass`
         -   `css`
+    -   [x] replace _{_*{*`VAR_NAME`*}*_}_ (注意: 为了防止 stylelint 报错, 需要将变量用引号包裹起来, 内部会自动去除)
     -   [x] import `node_modules`
     -   [x] sourcemaps
     -   [x] minify (release) / expanded (debug)

--- a/src/compiler/compile-wxss.js
+++ b/src/compiler/compile-wxss.js
@@ -11,6 +11,7 @@ var inline = require("../lib/inline");
 // var empty = require("../lib/empty");
 var wxssImporter = require("../lib/wxss-importer");
 var replace = require("../lib/multi-replace");
+const pkgVar = require('../lib/package-var');
 var error = require("../log/error");
 const debug = require("../log/compile");
 const size = require("../log/size");
@@ -45,6 +46,7 @@ function compileScss(config, scssFile) {
                 distExt: ".wxss",
             }),
         )
+        .pipe(replace(pkgVar(config.var), undefined, "{{", "}}"))
         .pipe(
             sass({
                 ///@ts-ignore

--- a/src/compiler/compile-wxss.js
+++ b/src/compiler/compile-wxss.js
@@ -46,7 +46,8 @@ function compileScss(config, scssFile) {
                 distExt: ".wxss",
             }),
         )
-        .pipe(replace(pkgVar(config.var), undefined, "{{", "}}"))
+        .pipe(replace(pkgVar(config.var), undefined, "\"{{", "}}\""))
+        .pipe(replace(pkgVar(config.var), undefined, "'{{", "}}'"))
         .pipe(
             sass({
                 ///@ts-ignore

--- a/test/.mpconfig.jsonc
+++ b/test/.mpconfig.jsonc
@@ -3,6 +3,7 @@
     "var": {
         "APP_ID": "123456", //APPID
         "VERSION": "{{package.version}}",
-        "Vx": "{{packa}}"
+        "Vx": "{{packa}}",
+        "THEME_COLOR": "#fcc",
     },
 }

--- a/test/src/app.scss
+++ b/test/src/app.scss
@@ -7,17 +7,22 @@ app.scss
 @import "./wxss/npm.wxss"; // keep as wxss
 @import "./assets/b.wxss"; // import scss
 @import "./assets/a";
+
+$primary-color: {{THEME_COLOR}};
+
 .t{
-    background: 
+    background:
         url(./assets/images/arrow-up.svg);
     width: 20rpx;
 }
 
 view{
-    background: 
+    background:
     url('./assets/images/test.svg');
+    background-color: lighten($primary-color, 50%);
     width: calc(99% -5rpx);
     display: flex;
+    color: '{{THEME_COLOR}}';
 }
 
 .x{

--- a/test/src/app.scss
+++ b/test/src/app.scss
@@ -8,18 +8,20 @@ app.scss
 @import "./assets/b.wxss"; // import scss
 @import "./assets/a";
 
-$primary-color: {{THEME_COLOR}};
 
 .t{
     background:
-        url(./assets/images/arrow-up.svg);
+    url(./assets/images/arrow-up.svg);
     width: 20rpx;
 }
 
+$primary-color: '{{THEME_COLOR}}';
+$secondary-color: "{{THEME_COLOR}}";
+
 view{
-    background:
-    url('./assets/images/test.svg');
-    background-color: lighten($primary-color, 50%);
+    background: lighten($secondary-color, 90%)
+      url('./assets/images/test.svg');
+    background-color: mix($primary-color, #000);
     width: calc(99% -5rpx);
     display: flex;
     color: '{{THEME_COLOR}}';


### PR DESCRIPTION
我在使用该工具时, 需要同时将一个变量用在wxss和js中(应用主题色)

我尝试在wxss compiler时替换变量, 经过 `cd test` `npm run test` 这一步成功了, 也生成了正确的结果.

但是stylelint报错了, 像下面这样

<img width="582" alt="图片" src="https://user-images.githubusercontent.com/9391981/61503941-28105800-aa0c-11e9-8f7a-9ed883fcc1db.png">

我尝试过将 18 行的 `{{THEME_COLOR}}` 加上引号, 但是出现了以下错误

<img width="456" alt="图片" src="https://user-images.githubusercontent.com/9391981/61503972-59892380-aa0c-11e9-8ae4-2b28c71558b0.png">

我不知道该怎么避免stylelint报错, 有什么办法吗?